### PR TITLE
fix when NSNotFound is returned

### DIFF
--- a/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalAggregation.m
+++ b/MagicalRecord/Categories/NSManagedObject/NSManagedObject+MagicalAggregation.m
@@ -79,9 +79,14 @@
     }
 	
 	NSUInteger count = [context countForFetchRequest:request error:&error];
-	[MagicalRecord handleErrors:error];
+
+  if (error) {
+    [MagicalRecord handleErrors:error];
+    return 0;
+  }
+
     
-    return count;
+  return count;
 }
 
 + (BOOL) MR_hasAtLeastOneEntity


### PR DESCRIPTION
`NSNotFound` value is `9223372036854775807` which causes overflow when you put it into `Int` in swift.
